### PR TITLE
Updated HsLua version in Stack.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
 install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - ulimit -n 4096
-  - stack --no-terminal --install-ghc build --flag hslua:lua501 --flag hslua:use-pkgconfig
-
+  - stack --no-terminal --install-ghc build
 script:
   - stack exec lua-version
   - stack exec callbacks

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,6 @@ flags: {}
 packages:
   - '.'
 extra-deps:
-  - hslua-0.9.1
+  - hslua-1.0.3.2
 resolver: lts-9.8
 


### PR DESCRIPTION
The current build is failing due to mismatch in version of HsLua in `stack.yaml` and `.cabal` file.
I updated version to the latest.